### PR TITLE
add approval status and API function for API

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -18,6 +18,7 @@ export interface Availability {
   date: string;
   shift: 'MORNING' | 'AFTERNOON' | 'NIGHT';
   status: 'AVAILABLE' | 'UNAVAILABLE' | 'PREFERRED_TO_WORK';
+  approvalStatus: 'PENDING' | 'CONFIRMED' | 'REFUSED';
   user?: {
     id: string;
     name: string;
@@ -124,6 +125,14 @@ export const api = createApi({
       }),
       invalidatesTags: ["Availability"],
     }),
+    updateAvailabilityApproval: build.mutation<Availability, { id: string, approvalStatus: 'CONFIRMED' | 'REFUSED' | 'PENDING' }>({
+      query: ({ id, approvalStatus }) => ({
+        url: `/availability/${id}/approval`,
+        method: 'PATCH',
+        body: { approvalStatus },
+      }),
+      invalidatesTags: ["Availability"],
+    }),
 
     // --- Schedule ---
     getSchedules: build.query<Schedule[], void>({
@@ -152,6 +161,7 @@ export const {
   useUpdateAvailabilityMutation,
   useAddAvailabilityMutation,
   useDeleteAvailabilityMutation,
+  useUpdateAvailabilityApprovalMutation,
   // Schedule
   useGetSchedulesQuery,
   useUpdateScheduleMutation,

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -34,6 +34,12 @@ enum Position {
   HEAD_WAITER
 }
 
+enum ApprovalStatus {
+  PENDING
+  CONFIRMED
+  REFUSED
+}
+
 model User {
   id        String   @id @default(uuid())
   name      String
@@ -48,12 +54,13 @@ model User {
 }
 
 model Availability {
-  id        String             @id @default(uuid())
-  date      DateTime           @db.Date
-  shift     Shift
-  status    AvailabilityStatus @default(AVAILABLE)
-  user      User               @relation(fields: [userId], references: [id])
-  userId    String
+  id              String             @id @default(uuid())
+  date            DateTime           @db.Date
+  shift           Shift
+  status          AvailabilityStatus @default(AVAILABLE)
+  approvalStatus  ApprovalStatus     @default(PENDING)
+  user            User               @relation(fields: [userId], references: [id])
+  userId          String
   @@unique([userId, date, shift])
 } 
 

--- a/server/prisma/seedData/availabilities.json
+++ b/server/prisma/seedData/availabilities.json
@@ -4,34 +4,39 @@
     "date": "2026-04-10T00:00:00.000Z",
     "shift": "MORNING",
     "userId": "bbbbbbbb-0000-0000-0000-000000000001",
-    "status": "AVAILABLE"
+    "status": "AVAILABLE",
+    "approvalStatus": "CONFIRMED"
   },
   {
     "id": "cccccccc-0000-0000-0000-000000000002",
     "date": "2026-04-10T00:00:00.000Z",
     "shift": "AFTERNOON",
     "userId": "bbbbbbbb-0000-0000-0000-000000000002",
-    "status": "UNAVAILABLE"
+    "status": "UNAVAILABLE",
+    "approvalStatus": "REFUSED"
   },
   {
     "id": "cccccccc-0000-0000-0000-000000000003",
     "date": "2026-04-11T00:00:00.000Z",
     "shift": "NIGHT",
     "userId": "bbbbbbbb-0000-0000-0000-000000000003",
-    "status": "PREFERRED_TO_WORK"
+    "status": "PREFERRED_TO_WORK",
+    "approvalStatus": "PENDING"
   },
   {
     "id": "cccccccc-0000-0000-0000-000000000004",
     "date": "2026-04-11T00:00:00.000Z",
     "shift": "MORNING",
     "userId": "bbbbbbbb-0000-0000-0000-000000000004",
-    "status": "AVAILABLE"
+    "status": "AVAILABLE",
+    "approvalStatus": "CONFIRMED"
   },
   {
     "id": "cccccccc-0000-0000-0000-000000000005",
     "date": "2026-04-12T00:00:00.000Z",
     "shift": "AFTERNOON",
     "userId": "bbbbbbbb-0000-0000-0000-000000000005",
-    "status": "UNAVAILABLE"
+    "status": "UNAVAILABLE",
+    "approvalStatus": "PENDING"
   }
 ]

--- a/server/src/routes/availability.ts
+++ b/server/src/routes/availability.ts
@@ -57,12 +57,13 @@ router.put('/:employeeId', async (req: Request, res: Response): Promise<void> =>
             shift,
           },
         },
-        update: { status },
+        update: { status, approvalStatus: 'PENDING' },
         create: {
           userId: employeeId as string,
           date: new Date(date),
           shift,
           status,
+          approvalStatus: 'PENDING',
         },
       })
     )
@@ -93,6 +94,7 @@ router.post('/', async (req: Request, res: Response): Promise<void> => {
         date: new Date(parsed.data.date),
         shift: parsed.data.shift,
         status: parsed.data.status,
+        approvalStatus: 'PENDING',
       },
     });
     res.status(201).json(availability);
@@ -116,6 +118,27 @@ router.delete('/:id', async (req: Request, res: Response): Promise<void> => {
     res.status(204).send();
   } catch (error) {
     res.status(500).json({ error: 'Failed to delete availability or record not found' });
+  }
+});
+
+// PATCH /availability/:id/approval
+router.patch('/:id/approval', async (req: Request, res: Response): Promise<void> => {
+  const { id } = req.params;
+  const { approvalStatus } = req.body;
+
+  if (!['CONFIRMED', 'REFUSED', 'PENDING'].includes(approvalStatus)) {
+    res.status(400).json({ error: 'Invalid approval status' });
+    return;
+  }
+
+  try {
+    const updated = await prisma.availability.update({
+      where: { id: id as string },
+      data: { approvalStatus: approvalStatus as any },
+    });
+    res.json(updated);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to update approval status' });
   }
 });
 


### PR DESCRIPTION
- Added a new ApprovalStatus enum and an approvalStatus field to the  Availability model in  prisma/schema.prisma.
- Added PATCH /availability/:id/approval to allow administrators to set the status to CONFIRMED or REFUSED.
